### PR TITLE
Fix memory leak and unhandled memory fault in `schema-from-object`

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,6 +24,8 @@ This library also utilizes =libgobject= and =libarrow= which must be on your CFF
 
 The low-level code is generated with [[https://github.com/kat-co/gir2cl][gir2cl]] and should not be edited by hand.
 
+For tests, I'm experimenting with the [[https://golang.org][Go]] style of tests where the test files are alongside the source files and appended with ~-test~. The tests are still in a different system and can be run with =(asdf:test-system :cl-apache-arrow)=.
+
 * How to Utilize the Library
 
 The high-level portion of the code is currently centered around streamlining writing out Parquet files based on CLOS definitions. A metaclass, =entity-class= is provided which, when used, will allow you to specify =:arrow-type= and =:arrow-field-name= on CLOS classes.

--- a/cl-apache-arrow.asd
+++ b/cl-apache-arrow.asd
@@ -1,12 +1,11 @@
-;;;; Copyright (c) 2019 Katherine Cox-Buday <cox.katherine.e@gmail.com>
-
 (asdf:defsystem #:cl-apache-arrow
   :description "Describe cl-apache-arrow here"
   :author "Katherine Cox-Buday <cox.katherine.e@gmail.com>"
   :license  "Apache-2.0"
-  :version "0.0.1"
+  :version "0.0.2"
   :depends-on (cl-gobject-introspection
-               closer-mop)
+               closer-mop
+               trivial-garbage)
   :serial t
   :components ((:module "src"
                 :components
@@ -15,4 +14,16 @@
                (:file "parquet-low-level")
                (:file "arrow")
                (:file "parquet")
-                 (:file "utils")))))
+                 (:file "utils"))))
+  :in-order-to ((test-op (test-op "cl-apache-arrow/tests"))))
+
+(defsystem "cl-apache-arrow/tests"
+  :description "Test system for cl-apache-arrow"
+  :author "Katherine Cox-Buday <cox.katherine.e@gmail.com>"
+  :license "Apache-2.0"
+  :depends-on ("cl-apache-arrow"
+               "rove")
+  :components ((:module "src"
+                :components
+                ((:file "utils-test"))))
+  :perform (test-op (op c) (symbol-call :rove :run c)))

--- a/src/arrow.lisp
+++ b/src/arrow.lisp
@@ -8,18 +8,27 @@
 
 (cffi:defctype glist-pointer :pointer)
 
+(cffi:defctype gpointer :pointer)
+
 (cffi:defcstruct g-list
   (data :pointer)
-  (next :pointer)
-  (prev :pointer))
+  (next (:pointer (:struct g-list)))
+  (prev (:pointer (:struct g-list))))
 
-(cffi:defcfun ("g_list_append" g-list-append) (:pointer (:struct g-list))
+(cffi:defcfun ("g_list_prepend" g-list-prepend) (:pointer (:struct g-list))
   (list (:pointer (:struct g-list)))
   (data :pointer))
 
 (cffi:defcfun ("g_list_concat" g-list-concat) (:pointer (:struct g-list))
   (list-1 (:pointer (:struct g-list)))
   (list-2 (:pointer (:struct g-list))))
+
+(cffi:defcfun ("g_list_free" g-list-free) :void
+  (mem (:pointer (:struct g-list))))
+
+(cffi:defcfun ("g_list_nth_data" g-list-nth-data) gpointer
+  (list (:pointer (:struct g-list)))
+  (n :unsigned-int))
 
 ;; High level
 
@@ -49,3 +58,58 @@
     (with-slots (native-pointer)
         array-builder
       (gir:invoke (native-pointer "finish")))))
+
+(defclass field-list ()
+  ((g-list :type cffi:foreign-pointer
+           :initarg :g-list
+           :initform (cffi:null-pointer)
+           :accessor g-list)
+   (lisp-list :type list
+              :initarg :lisp-list
+              :initform (list)
+              :accessor lisp-list))
+
+  (:documentation
+   "It is often necessary to couple the lifetime of a g-list
+   containing fields with the lifetime of the fields themselves. If
+   this is not done, it is easy to end up with a g-list containing
+   fields that have been garbage collected which can cause non-obvious
+   bugs. This class handles building up both lists simultaneously to
+   help couple their lifetimes."))
+
+(defmethod concat ((lhs field-list) rhs)
+  (check-type rhs field-list)
+
+  (with-accessors ((lhs-g-list g-list) (lhs-list lisp-list))
+      lhs
+    (with-accessors ((rhs-g-list g-list) (rhs-list lisp-list))
+        rhs
+      (let ((new-g-list (g-list-concat lhs-g-list rhs-g-list))
+            (new-list (append lhs-list rhs-list)))
+        (make-instance 'field-list :g-list new-g-list
+                                   :lisp-list new-list)))))
+
+(defmethod prepend-field ((l field-list) field)
+  "Prepends the given field to both the g-list and the list."
+  (check-type field arrow-low-level:field)
+
+  (with-accessors ((g-list g-list) (list lisp-list))
+      l
+    (setf
+     g-list (g-list-prepend g-list (gir::this-of (native-pointer field)))
+     list (cons field list))))
+
+(defmethod initialize-instance :after ((l field-list) &key)
+  "Sets up a finalizer for the field-list which ensures that the
+underlying GList is freed when this object is garbage collected."
+  ;; The purpose of the let block is so that the function being passed
+  ;; into cffi:finalize doesn't close around a slot-value of
+  ;; field-list. If it did, the object would never get garbage collected
+  (let ((g-list (cffi:null-pointer)))
+    (with-accessors ((g-list* g-list))
+        l
+      (setf g-list g-list*))
+    (unless (cffi:null-pointer-p g-list)
+      (trivial-garbage:finalize
+       l
+       (lambda () (g-list-free g-list))))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -596,7 +596,12 @@
            entity-class
            entity-slot-definition
            arrow-field-name
-           with-field-builders))
+           with-field-builders
+           field-list
+           prepend-field
+           concat
+           lisp-list
+           g-list))
 
 (defpackage #:parquet
   (:use #:cl)

--- a/src/utils-test.lisp
+++ b/src/utils-test.lisp
@@ -1,0 +1,62 @@
+(defpackage cl-apache-arrow/tests/utils
+  (:use :cl
+        :arrow
+        :rove))
+(in-package :cl-apache-arrow/tests/utils)
+
+(defclass test-class ()
+  ((field-a :initarg :field-a
+            :arrow-field-name "arrow-field-a"
+            :arrow-type (arrow-low-level:make-string-data-type-new))
+   (field-b :initarg :field-b
+            :arrow-field-name "arrow-field-b"
+            :arrow-type (arrow-low-level:make-int32data-type-new)))
+
+  (:metaclass arrow:entity-class))
+
+(let ((o (make-instance 'test-class
+                        :field-a "value-a"
+                        :field-b 1)))
+
+  (deftest schema-from-object
+    (testing "The correct schema is generated."
+      (let ((schema (arrow:schema-from-object o)))
+        (ok (string= (arrow-low-level:arrow-schema-to-string schema)
+                     "arrow-field-a: string
+arrow-field-b: int32"))))
+
+    (testing "The correct field builders are generated."
+      (multiple-value-bind (schema field-builders)
+          (arrow:schema-from-object o)
+        (let ((field-builder-types (mapcar #'type-of field-builders)))
+          (ok (equalp field-builder-types
+                      '(arrow-low-level:string-array-builder
+                        arrow-low-level:int32array-builder)))))))
+
+  (deftest field-list
+    (testing "Prepending field-list gives expected sequence"
+      (let* ((lhs-field-list (make-instance 'arrow:field-list))
+             (rhs-field-list (make-instance 'arrow:field-list))
+             (string-data-type (arrow-low-level:native-pointer
+                                (arrow-low-level:make-string-data-type-new)))
+             (a (arrow-low-level:make-field-new "a" string-data-type))
+             (b (arrow-low-level:make-field-new "b" string-data-type))
+             (c (arrow-low-level:make-field-new "c" string-data-type))
+             (d (arrow-low-level:make-field-new "d" string-data-type)))
+
+        (prepend-field lhs-field-list b)
+        (prepend-field lhs-field-list a)
+
+        (prepend-field rhs-field-list d)
+        (prepend-field rhs-field-list c)
+
+        (let ((new-field-list (concat lhs-field-list rhs-field-list)))
+          (ok (equalp (arrow:lisp-list new-field-list)
+                      (append (arrow:lisp-list lhs-field-list)
+                              (arrow:lisp-list rhs-field-list))))
+          (loop
+            for f in (list a b c d)
+            for i upto 3
+            do (ok (cffi:pointer-eq
+                    (arrow::g-list-nth-data (arrow:g-list new-field-list) i)
+                    (gir::this-of (arrow-low-level:native-pointer f))))))))))


### PR DESCRIPTION
The memory leak was a result of not freeing g-lists which we created,
and the unhandled memory fault was from the garbage collector clearing
the data elements in a g-list before `make-arrow-schema-new` could
enumerate the list and pull out its elements.

This commit also introduces a test suite.

Fixes #2
Fixes #3